### PR TITLE
fix(web): add 'in-review' to status dropdown and graph legend

### DIFF
--- a/apps/web/src/components/graph/TaskNode.tsx
+++ b/apps/web/src/components/graph/TaskNode.tsx
@@ -4,6 +4,7 @@ import { Handle, Position } from "@xyflow/react";
 const STATUS_BG: Record<string, string> = {
   pending: "bg-yellow-50 border-yellow-300 dark:bg-yellow-900/20 dark:border-yellow-700",
   "in-progress": "bg-blue-50 border-blue-300 dark:bg-blue-900/20 dark:border-blue-700",
+  "in-review": "bg-purple-50 border-purple-300 dark:bg-purple-900/20 dark:border-purple-700",
   completed: "bg-green-50 border-green-300 dark:bg-green-900/20 dark:border-green-700",
   blocked: "bg-red-50 border-red-300 dark:bg-red-900/20 dark:border-red-700",
   cancelled: "bg-gray-50 border-gray-300 dark:bg-gray-800 dark:border-gray-600",

--- a/apps/web/src/components/tasks/TaskEditFormFields.test.tsx
+++ b/apps/web/src/components/tasks/TaskEditFormFields.test.tsx
@@ -51,6 +51,23 @@ describe("FieldGrid", () => {
     expect(options).toEqual(STATUSES);
   });
 
+  it("exposes all 6 spec statuses including in-review", () => {
+    const { container } = renderFieldGrid();
+    const select = getSelectByLabel(container, "Status");
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toEqual(
+      expect.arrayContaining([
+        "pending",
+        "in-progress",
+        "in-review",
+        "completed",
+        "blocked",
+        "cancelled",
+      ]),
+    );
+    expect(options).toHaveLength(6);
+  });
+
   it("renders priority options with empty default", () => {
     const { container } = renderFieldGrid();
     const select = getSelectByLabel(container, "Priority");

--- a/apps/web/src/components/tasks/TaskTable/constants.ts
+++ b/apps/web/src/components/tasks/TaskTable/constants.ts
@@ -1,4 +1,4 @@
-export const STATUSES = ["pending", "in-progress", "completed", "blocked", "cancelled"];
+export const STATUSES = ["pending", "in-progress", "in-review", "completed", "blocked", "cancelled"];
 export const PRIORITIES = ["critical", "high", "medium", "low"];
 export const EFFORTS = ["small", "medium", "large"];
 export const TYPES = ["feature", "bug", "improvement", "chore", "docs"];
@@ -6,6 +6,7 @@ export const TYPES = ["feature", "bug", "improvement", "chore", "docs"];
 export const STATUS_COLORS: Record<string, string> = {
   pending: "bg-yellow-100 text-yellow-800 font-medium ring-1 ring-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-300 dark:ring-yellow-700",
   "in-progress": "bg-blue-100 text-blue-800 font-medium ring-1 ring-blue-300 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-700",
+  "in-review": "bg-purple-100 text-purple-800 font-medium ring-1 ring-purple-300 dark:bg-purple-900/30 dark:text-purple-300 dark:ring-purple-700",
   completed: "bg-green-100 text-green-800 font-medium ring-1 ring-green-300 dark:bg-green-900/30 dark:text-green-300 dark:ring-green-700",
   blocked: "bg-red-100 text-red-800 font-medium ring-1 ring-red-300 dark:bg-red-900/30 dark:text-red-300 dark:ring-red-700",
   cancelled: "bg-gray-100 text-gray-600 font-medium ring-1 ring-gray-300 dark:bg-gray-700/50 dark:text-gray-400 dark:ring-gray-600",


### PR DESCRIPTION
## Summary

The spec defines 6 task statuses (`pending`, `in-progress`, `in-review`, `completed`, `blocked`, `cancelled`) and the CLI accepts all 6, but the web UI only exposed 5 — `in-review` was missing from the task edit dropdown, the task table / board / graph filter chips, and the graph node color map. Tasks set to `in-review` via the CLI were invisible in status-filtered views and couldn't be re-set through the UI, forcing users who follow the full `pending → in-progress → in-review → completed` flow to collapse back to 3 states.

This PR adds `in-review` to the single shared `STATUSES` constant (which feeds the edit dropdown, task table filter, graph filter, and board filter bar) and gives it a purple color treatment in both the status badge palette (`STATUS_COLORS`) and the graph node background map (`STATUS_BG`). Board columns are already driven by the Go SDK's `board.statusOrder()` which knows about `StatusInReview`, so no backend changes were needed — a column will appear automatically when `in-review` tasks exist.

Statuses are ordered to match the spec's designed flow (`pending → in-progress → in-review → completed → blocked → cancelled`).

## Changes

- `apps/web/src/components/tasks/TaskTable/constants.ts` — add `in-review` to `STATUSES` and `STATUS_COLORS`
- `apps/web/src/components/graph/TaskNode.tsx` — add `in-review` entry to `STATUS_BG`
- `apps/web/src/components/tasks/TaskEditFormFields.test.tsx` — new regression test asserting the Status `<select>` exposes all 6 spec statuses including `in-review`

## Test plan

- [ ] `pnpm test` — 656/656 passing (79 test files), including new 6-status assertion
- [ ] `pnpm lint` — clean
- [ ] `pnpm typeCheck` — clean
- [ ] Manual: start `taskmd web`, set a task to `in-review` via CLI, confirm it appears in the dashboard, confirm the edit dropdown now offers `in-review`, confirm the board renders an `in-review` column when such tasks exist