### PR TITLE
feat: shared task dir for parallel agents + GitHub-style worklog comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ apps/docs/.vitepress/dist/
 settings.local.json
 .claude/worktrees
 apps/web/tsconfig.app.tsbuildinfo
+
+# taskmd runtime locks and atomic-write temp files (machine-local, never committed)
+.taskmd/locks/
+.tmp-*

--- a/apps/cli/internal/cli/env_task_dir_test.go
+++ b/apps/cli/internal/cli/env_task_dir_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"testing"
+)
+
+// TestResolveTaskDir_EnvVarOverridesConfig verifies that TASKMD_TASK_DIR is
+// honored as the shared-tracker switch, overriding per-worktree committed
+// config (the taskDir fallback here stands in for a config value).
+func TestResolveTaskDir_EnvVarOverridesConfig(t *testing.T) {
+	resetViper()
+	resetFlags()
+	defer resetViper()
+	defer resetFlags()
+
+	taskDir = "/some/local/tasks"
+	t.Setenv("TASKMD_TASK_DIR", "/shared/tasks")
+
+	got := resolveTaskDir()
+	if want := "/shared/tasks"; got != want {
+		t.Errorf("resolveTaskDir() = %q, want %q (env should override config)", got, want)
+	}
+}
+
+// TestResolveTaskDir_ExplicitFlagBeatsEnvVar verifies that an explicit
+// --task-dir CLI flag (a deliberate per-invocation override) wins over the
+// ambient TASKMD_TASK_DIR env var.
+func TestResolveTaskDir_ExplicitFlagBeatsEnvVar(t *testing.T) {
+	resetViper()
+	resetFlags()
+	defer resetViper()
+	defer resetFlags()
+
+	t.Setenv("TASKMD_TASK_DIR", "/shared/tasks")
+
+	tf := rootCmd.PersistentFlags().Lookup("task-dir")
+	if err := tf.Value.Set("/explicit/tasks"); err != nil {
+		t.Fatalf("set task-dir flag: %v", err)
+	}
+	tf.Changed = true
+	defer func() {
+		_ = tf.Value.Set(".")
+		tf.Changed = false
+	}()
+
+	got := resolveTaskDir()
+	if want := "/explicit/tasks"; got != want {
+		t.Errorf("resolveTaskDir() = %q, want %q (explicit flag should beat env)", got, want)
+	}
+}
+
+// TestResolveTaskDir_EnvVarUnsetFallsThrough verifies that when the env var is
+// absent, resolution falls through to the existing behavior.
+func TestResolveTaskDir_EnvVarUnsetFallsThrough(t *testing.T) {
+	resetViper()
+	resetFlags()
+	defer resetViper()
+	defer resetFlags()
+
+	taskDir = "/local/tasks"
+
+	got := resolveTaskDir()
+	if want := "/local/tasks"; got != want {
+		t.Errorf("resolveTaskDir() = %q, want %q", got, want)
+	}
+}

--- a/apps/cli/internal/cli/root.go
+++ b/apps/cli/internal/cli/root.go
@@ -211,6 +211,15 @@ func resolveTaskDir() string {
 		return dirFlag.Value.String()
 	}
 
+	// TASKMD_TASK_DIR env var overrides per-worktree config so that parallel
+	// agents in separate git worktrees can be pointed at one shared task
+	// directory (the source of truth). Use an absolute path for this to be
+	// meaningful across worktrees. It sits below explicit CLI flags (a
+	// deliberate per-invocation override wins) but above committed config.
+	if envDir := os.Getenv("TASKMD_TASK_DIR"); envDir != "" {
+		return envDir
+	}
+
 	// Check config file: support both "task-dir" and "dir" YAML keys.
 	// We must bypass viper's pflag binding (which returns the flag default)
 	// by checking the config file values directly via viper.InConfig.

--- a/apps/cli/internal/cli/set.go
+++ b/apps/cli/internal/cli/set.go
@@ -155,7 +155,7 @@ func runSet(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := taskfile.UpdateTaskFile(task.FilePath, req); err != nil {
+	if err := taskfile.UpdateTaskFileLocked(scanDir, task.FilePath, task.ID, req); err != nil {
 		return err
 	}
 

--- a/apps/cli/internal/cli/templates/CLAUDE.md
+++ b/apps/cli/internal/cli/templates/CLAUDE.md
@@ -85,10 +85,14 @@ When worklogs are enabled (`worklogs: true` in `.taskmd.yaml`), record progress 
 
 ```bash
 taskmd worklog <id> --add "Started implementation. Approach: ..."
+taskmd worklog <id> --add "..." --author "claude (agent)"   # attribute the entry
 taskmd worklog <id>            # View worklog
 ```
 
 Write entries when starting, making key decisions, hitting blockers, or finishing.
+Pass `--author` so entries are attributed (agents should identify themselves,
+e.g. `--author "claude (agent)"`); without it the author defaults to the git
+`user.name`.
 
 ## Validation
 

--- a/apps/cli/internal/cli/worklog.go
+++ b/apps/cli/internal/cli/worklog.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -13,6 +15,7 @@ import (
 
 var (
 	worklogAdd    string
+	worklogAuthor string
 	worklogFormat string
 )
 
@@ -25,6 +28,7 @@ var worklogCmd = &cobra.Command{
 Examples:
   taskmd worklog 015                        # view worklog entries
   taskmd worklog 015 --add "Started implementation"
+  taskmd worklog 015 --add "Reviewed" --author "claude (agent)"
   taskmd worklog 015 --format json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runWorklog,
@@ -34,7 +38,23 @@ func init() {
 	rootCmd.AddCommand(worklogCmd)
 
 	worklogCmd.Flags().StringVar(&worklogAdd, "add", "", "append a new worklog entry")
+	worklogCmd.Flags().StringVar(&worklogAuthor, "author", "", "author of the entry (defaults to git user.name, then $USER)")
 	worklogCmd.Flags().StringVar(&worklogFormat, "format", "text", "output format (text, json, yaml)")
+}
+
+// resolveWorklogAuthor returns the explicit author if given, otherwise the
+// git user.name / user.email, then $USER, then "" (anonymous).
+func resolveWorklogAuthor(explicit string) string {
+	if a := strings.TrimSpace(explicit); a != "" {
+		return a
+	}
+	for _, args := range [][]string{{"config", "user.name"}, {"config", "user.email"}} {
+		out, err := exec.Command("git", args...).Output()
+		if v := strings.TrimSpace(string(out)); err == nil && v != "" {
+			return v
+		}
+	}
+	return strings.TrimSpace(os.Getenv("USER"))
 }
 
 func runWorklog(cmd *cobra.Command, args []string) error {
@@ -66,10 +86,15 @@ func runWorklog(cmd *cobra.Command, args []string) error {
 
 	// Add mode
 	if worklogAdd != "" {
-		if err := worklog.AppendEntryLocked(scanDir, wlPath, taskID, worklogAdd); err != nil {
+		author := resolveWorklogAuthor(worklogAuthor)
+		if err := worklog.AppendEntryLocked(scanDir, wlPath, taskID, author, worklogAdd); err != nil {
 			return fmt.Errorf("failed to add worklog entry: %w", err)
 		}
-		fmt.Fprintf(os.Stderr, "Added worklog entry for task %s\n", taskID)
+		if author != "" {
+			fmt.Fprintf(os.Stderr, "Added worklog entry for task %s (as %s)\n", taskID, author)
+		} else {
+			fmt.Fprintf(os.Stderr, "Added worklog entry for task %s\n", taskID)
+		}
 		return nil
 	}
 
@@ -114,7 +139,12 @@ func outputWorklogText(wl *worklog.Worklog, w io.Writer) error {
 		if i > 0 {
 			fmt.Fprintln(w)
 		}
-		fmt.Fprintf(w, "%s %s\n", formatLabel("##", r), formatDim(entry.Timestamp.Format("2006-01-02T15:04:05Z07:00"), r))
+		ts := formatDim(entry.Timestamp.Format("2006-01-02T15:04:05Z07:00"), r)
+		if entry.Author != "" {
+			fmt.Fprintf(w, "%s %s %s\n", formatLabel("##", r), ts, formatTaskID(entry.Author, r))
+		} else {
+			fmt.Fprintf(w, "%s %s\n", formatLabel("##", r), ts)
+		}
 		if entry.Content != "" {
 			fmt.Fprintf(w, "\n%s\n", entry.Content)
 		}

--- a/apps/cli/internal/cli/worklog.go
+++ b/apps/cli/internal/cli/worklog.go
@@ -66,7 +66,7 @@ func runWorklog(cmd *cobra.Command, args []string) error {
 
 	// Add mode
 	if worklogAdd != "" {
-		if err := worklog.AppendEntry(wlPath, worklogAdd); err != nil {
+		if err := worklog.AppendEntryLocked(scanDir, wlPath, taskID, worklogAdd); err != nil {
 			return fmt.Errorf("failed to add worklog entry: %w", err)
 		}
 		fmt.Fprintf(os.Stderr, "Added worklog entry for task %s\n", taskID)

--- a/apps/cli/internal/mcp/set.go
+++ b/apps/cli/internal/mcp/set.go
@@ -69,7 +69,7 @@ func handleSet(_ context.Context, _ *gomcp.CallToolRequest, input SetInput) (*go
 
 	applyStatusTransitionDates(&req, task)
 
-	if err := taskfile.UpdateTaskFile(task.FilePath, req); err != nil {
+	if err := taskfile.UpdateTaskFileLocked(taskDir, task.FilePath, task.ID, req); err != nil {
 		return nil, nil, fmt.Errorf("update failed: %w", err)
 	}
 

--- a/apps/cli/internal/web/export.go
+++ b/apps/cli/internal/web/export.go
@@ -153,14 +153,7 @@ func buildWorklogEntries(t *model.Task) []WorklogEntryJSON {
 	if err != nil {
 		return []WorklogEntryJSON{}
 	}
-	entries := make([]WorklogEntryJSON, len(wl.Entries))
-	for i, e := range wl.Entries {
-		entries[i] = WorklogEntryJSON{
-			Timestamp: e.Timestamp.Format("2006-01-02T15:04:05Z07:00"),
-			Content:   e.Content,
-		}
-	}
-	return entries
+	return worklogEntriesJSON(wl)
 }
 
 func generateBoardFiles(boardDir string, tasks []*model.Task) error {

--- a/apps/cli/internal/web/handlers.go
+++ b/apps/cli/internal/web/handlers.go
@@ -480,7 +480,27 @@ func reloadTask(dp *DataProvider, taskID string) (*model.Task, error) {
 // WorklogEntryJSON is a single worklog entry for the API.
 type WorklogEntryJSON struct {
 	Timestamp string `json:"timestamp"`
+	Author    string `json:"author,omitempty"`
 	Content   string `json:"content"`
+}
+
+// WorklogAddRequest is the POST body for adding a worklog entry.
+type WorklogAddRequest struct {
+	Author  string `json:"author"`
+	Content string `json:"content"`
+}
+
+// worklogEntriesJSON maps a parsed worklog to its API representation.
+func worklogEntriesJSON(wl *worklog.Worklog) []WorklogEntryJSON {
+	entries := make([]WorklogEntryJSON, len(wl.Entries))
+	for i, e := range wl.Entries {
+		entries[i] = WorklogEntryJSON{
+			Timestamp: e.Timestamp.Format("2006-01-02T15:04:05Z07:00"),
+			Author:    e.Author,
+			Content:   e.Content,
+		}
+	}
+	return entries
 }
 
 func handleWorklog(dp *DataProvider) http.HandlerFunc {
@@ -516,15 +536,61 @@ func handleWorklog(dp *DataProvider) http.HandlerFunc {
 			return
 		}
 
-		entries := make([]WorklogEntryJSON, len(wl.Entries))
-		for i, e := range wl.Entries {
-			entries[i] = WorklogEntryJSON{
-				Timestamp: e.Timestamp.Format("2006-01-02T15:04:05Z07:00"),
-				Content:   e.Content,
-			}
+		writeJSON(w, worklogEntriesJSON(wl))
+	}
+}
+
+// handleAddWorklog appends a worklog entry via POST /api/tasks/{id}/worklog and
+// returns the updated entry list. Writes go through the per-task lock.
+func handleAddWorklog(dp *DataProvider, readonly bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		dp := effectiveDP(r, dp)
+		if readonly {
+			writeError(w, http.StatusForbidden, "server is in read-only mode", nil)
+			return
 		}
 
-		writeJSON(w, entries)
+		taskID := r.PathValue("id")
+		if taskID == "" {
+			writeError(w, http.StatusBadRequest, "task ID is required", nil)
+			return
+		}
+
+		var body WorklogAddRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body", []string{err.Error()})
+			return
+		}
+		if strings.TrimSpace(body.Content) == "" {
+			writeError(w, http.StatusBadRequest, "content is required", nil)
+			return
+		}
+
+		tasks, err := dp.GetTasks()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load tasks", nil)
+			return
+		}
+		found := findTaskByID(tasks, taskID)
+		if found == nil {
+			writeError(w, http.StatusNotFound, "task not found: "+taskID, nil)
+			return
+		}
+
+		wlPath := worklog.WorklogPath(found.FilePath, taskID)
+		author := strings.TrimSpace(body.Author)
+		if err := worklog.AppendEntryLocked(dp.ScanDir(), wlPath, taskID, author, body.Content); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to add worklog entry", []string{err.Error()})
+			return
+		}
+		dp.Invalidate()
+
+		wl, err := worklog.ParseWorklog(wlPath)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to reload worklog", nil)
+			return
+		}
+		writeJSON(w, worklogEntriesJSON(wl))
 	}
 }
 

--- a/apps/cli/internal/web/handlers.go
+++ b/apps/cli/internal/web/handlers.go
@@ -426,7 +426,7 @@ func handleUpdateTask(dp *DataProvider, readonly bool) http.HandlerFunc {
 			return
 		}
 
-		if err := taskfile.UpdateTaskFile(found.FilePath, req); err != nil {
+		if err := taskfile.UpdateTaskFileLocked(dp.ScanDir(), found.FilePath, found.ID, req); err != nil {
 			handleFileUpdateError(w, err)
 			return
 		}

--- a/apps/cli/internal/web/handlers_test.go
+++ b/apps/cli/internal/web/handlers_test.go
@@ -1535,3 +1535,87 @@ func TestHandleBoard_WithProject(t *testing.T) {
 		t.Fatal("expected project task P01 in board response")
 	}
 }
+
+func TestHandleAddWorklog_Success(t *testing.T) {
+	dir := createTestTaskDir(t)
+	dp := NewDataProvider(dir, false)
+
+	body := strings.NewReader(`{"author":"alice","content":"first comment"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/001/worklog", body)
+	req.SetPathValue("id", "001")
+	rec := httptest.NewRecorder()
+
+	handleAddWorklog(dp, false)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var entries []WorklogEntryJSON
+	if err := json.Unmarshal(rec.Body.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Author != "alice" || entries[0].Content != "first comment" {
+		t.Errorf("unexpected entry: %+v", entries[0])
+	}
+
+	// Verify the worklog file was written with the author.
+	content, err := os.ReadFile(filepath.Join(dir, ".worklogs", "001.md"))
+	if err != nil {
+		t.Fatalf("worklog file not created: %v", err)
+	}
+	if !strings.Contains(string(content), "— alice") {
+		t.Errorf("worklog file missing author, got:\n%s", content)
+	}
+}
+
+func TestHandleAddWorklog_ReadOnly(t *testing.T) {
+	dir := createTestTaskDir(t)
+	dp := NewDataProvider(dir, false)
+
+	body := strings.NewReader(`{"content":"nope"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/001/worklog", body)
+	req.SetPathValue("id", "001")
+	rec := httptest.NewRecorder()
+
+	handleAddWorklog(dp, true)(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 in read-only mode, got %d", rec.Code)
+	}
+}
+
+func TestHandleAddWorklog_EmptyContent(t *testing.T) {
+	dir := createTestTaskDir(t)
+	dp := NewDataProvider(dir, false)
+
+	body := strings.NewReader(`{"author":"alice","content":"   "}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/001/worklog", body)
+	req.SetPathValue("id", "001")
+	rec := httptest.NewRecorder()
+
+	handleAddWorklog(dp, false)(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty content, got %d", rec.Code)
+	}
+}
+
+func TestHandleAddWorklog_NotFound(t *testing.T) {
+	dir := createTestTaskDir(t)
+	dp := NewDataProvider(dir, false)
+
+	body := strings.NewReader(`{"content":"hi"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/999/worklog", body)
+	req.SetPathValue("id", "999")
+	rec := httptest.NewRecorder()
+
+	handleAddWorklog(dp, false)(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}

--- a/apps/cli/internal/web/server.go
+++ b/apps/cli/internal/web/server.go
@@ -124,6 +124,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/tasks", handleTasks(s.dp))
 	mux.HandleFunc("GET /api/tasks/{id}", handleTaskByID(s.dp))
 	mux.HandleFunc("GET /api/tasks/{id}/worklog", handleWorklog(s.dp))
+	mux.HandleFunc("POST /api/tasks/{id}/worklog", handleAddWorklog(s.dp, s.config.ReadOnly))
 	mux.HandleFunc("PUT /api/tasks/{id}", handleUpdateTask(s.dp, s.config.ReadOnly))
 	mux.HandleFunc("GET /api/board", handleBoard(s.dp, s.config.Phases))
 	mux.HandleFunc("GET /api/graph", handleGraph(s.dp))

--- a/apps/docs/guide/best-practices.md
+++ b/apps/docs/guide/best-practices.md
@@ -607,6 +607,44 @@ scopes:
 
 Full setup with worklogs for audit trail, scopes for parallel AI sessions, and PR-review workflow for team coordination.
 
+## Sharing a task directory across worktrees {#shared-task-dir}
+
+When several agents (or an agent plus the web dashboard) work in parallel, you
+usually want them to share **one** task tracker so status changes and worklog
+comments are visible to everyone immediately — rather than each git worktree
+editing its own private copy of `tasks/` and reconciling later through merges.
+
+Point every process at the same directory with
+[`TASKMD_TASK_DIR`](/reference/configuration#taskmd-task-dir):
+
+```bash
+# In each worktree / agent environment
+export TASKMD_TASK_DIR=/abs/path/to/shared/tasks
+```
+
+Now `taskmd set`, `taskmd worklog`, the MCP server, and the web dashboard all
+read and write the same files, regardless of which worktree they run in.
+
+**Concurrency safety.** Sharing one directory means multiple processes may write
+at once. taskmd handles this automatically:
+
+- **Atomic writes** — task files are written via a temp file + rename, so a
+  reader (or scanner) never sees a half-written file.
+- **Per-task locking** — each write takes a short advisory lock at
+  `<task-dir>/.taskmd/locks/<id>.lock` for the duration of the read-modify-write.
+  Writers to the *same* task serialize; writers to *different* tasks never
+  contend. This prevents lost updates when, say, two agents update the same task
+  or post worklog comments concurrently.
+
+Notes:
+
+- Locking uses `flock` and is reliable on local filesystems (macOS, Linux). It is
+  **not** guaranteed on networked filesystems (NFS); keep the shared directory on
+  a local disk.
+- `.taskmd/locks/` and atomic-write temp files are machine-local — add
+  `.taskmd/locks/` and `.tmp-*` to `.gitignore` if the shared directory is itself
+  a git repository.
+
 ## What's Next?
 
 - **[CLI Guide](/guide/cli)** -- full command reference

--- a/apps/docs/guide/cli.md
+++ b/apps/docs/guide/cli.md
@@ -1019,6 +1019,9 @@ taskmd worklog 015
 # Add a new entry
 taskmd worklog 015 --add "Started implementation"
 
+# Attribute the entry to an author
+taskmd worklog 015 --add "Reviewed the approach" --author "claude (agent)"
+
 # JSON output
 taskmd worklog 015 --format json
 
@@ -1031,7 +1034,21 @@ taskmd worklog 015 --format yaml
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--add` | | Append a new worklog entry with the given text |
+| `--author` | git `user.name` → `user.email` → `$USER` | Author recorded on the entry |
 | `--format` | `text` | Output format (`text`, `json`, `yaml`) |
+
+**Entry format.** Each entry is written as a timestamped heading followed by the
+message. When an author is present it is appended to the heading:
+
+```markdown
+## 2026-07-14T13:29:44Z — claude (agent)
+
+Reviewed the approach
+```
+
+The author is optional and backward compatible — entries written without one
+(`## <timestamp>`) still parse. Agents should pass `--author` to identify
+themselves; for humans it defaults to the local git user.
 
 ### import - Import Tasks from External Sources
 
@@ -1626,7 +1643,9 @@ export TASKMD_DIR=./tasks
 export TASKMD_VERBOSE=true
 ```
 
-Environment variables have lower precedence than config files and CLI flags.
+Environment variables have lower precedence than config files and CLI flags,
+with one exception: [`TASKMD_TASK_DIR`](../reference/configuration#taskmd-task-dir)
+overrides `.taskmd.yaml` so multiple git worktrees can share one task directory.
 
 ## Troubleshooting
 

--- a/apps/docs/guide/web.md
+++ b/apps/docs/guide/web.md
@@ -165,7 +165,8 @@ Full detail page for a single task.
 
 - Rendered markdown body with full task description
 - Metadata panel showing status, priority, effort, type, tags, owner, and dependencies
-- Worklog timeline (if worklogs exist for the task)
+- Worklog timeline showing each entry's author and timestamp
+- **Comment box** to add worklog entries from the browser, with an optional author field (hidden in read-only mode)
 - **Edit form** for updating task fields directly in the browser (hidden in read-only mode)
 
 ## Web Features
@@ -220,7 +221,8 @@ taskmd web start --readonly
 When enabled:
 - The task edit form is hidden
 - Board drag-and-drop is disabled
-- The `PUT /api/tasks/{id}` endpoint returns `403 Forbidden`
+- The worklog comment box is hidden
+- The `PUT /api/tasks/{id}` and `POST /api/tasks/{id}/worklog` endpoints return `403 Forbidden`
 - All read operations work normally
 
 ### Board Filters
@@ -280,6 +282,7 @@ The web server exposes a JSON API you can access directly. All endpoints return 
 | `GET` | `/api/tasks` | List all tasks (excludes body content) |
 | `GET` | `/api/tasks/{id}` | Get a single task with full body and worklog metadata |
 | `GET` | `/api/tasks/{id}/worklog` | Get worklog entries for a task |
+| `POST` | `/api/tasks/{id}/worklog` | Add a worklog entry/comment (disabled in read-only mode) |
 | `PUT` | `/api/tasks/{id}` | Update task fields (disabled in read-only mode) |
 | `GET` | `/api/search?q=<query>` | Full-text search across task titles and bodies |
 
@@ -315,6 +318,11 @@ curl http://localhost:8080/api/tasks/042
 
 # Get worklog for a task
 curl http://localhost:8080/api/tasks/042/worklog
+
+# Add a worklog entry/comment
+curl -X POST http://localhost:8080/api/tasks/042/worklog \
+  -H 'Content-Type: application/json' \
+  -d '{"author": "alice", "content": "Reviewed the approach — LGTM"}'
 
 # Update a task's status
 curl -X PUT http://localhost:8080/api/tasks/042 \
@@ -368,6 +376,27 @@ Valid values:
 - **type**: `feature`, `bug`, `improvement`, `chore`, `docs`
 
 Returns the updated task detail on success, or a `400` with validation errors for invalid values.
+
+### POST /api/tasks/{id}/worklog
+
+Append a worklog entry (comment) to a task. Send a JSON body with the comment
+text and an optional author:
+
+```json
+{
+  "author": "alice",
+  "content": "Reviewed the approach — LGTM"
+}
+```
+
+- `content` is required; a `400` is returned if it is empty.
+- `author` is optional; when present it is recorded on the entry heading
+  (`## <timestamp> — <author>`).
+- Returns the updated list of worklog entries on success.
+- Returns `403 Forbidden` in read-only mode and `404` if the task does not exist.
+
+In the UI, the task detail page has a **comment box** below the worklog
+timeline (hidden in read-only mode) that posts to this endpoint.
 
 ## Advanced Usage
 

--- a/apps/docs/reference/configuration.md
+++ b/apps/docs/reference/configuration.md
@@ -195,6 +195,29 @@ export TASKMD_VERBOSE=true
 4. Environment variables
 5. Built-in defaults
 
+### `TASKMD_TASK_DIR` — shared task directory {#taskmd-task-dir}
+
+`TASKMD_TASK_DIR` points taskmd at a specific task directory and is the
+recommended way to make several git worktrees operate on **one shared task
+tracker** (see [Sharing a task directory across worktrees](../guide/best-practices#shared-task-dir)).
+
+```bash
+export TASKMD_TASK_DIR=/abs/path/to/shared/tasks
+```
+
+Unlike other `TASKMD_` variables, `TASKMD_TASK_DIR` intentionally **overrides
+the project/global `.taskmd.yaml` value** so that agents launched inside
+different worktrees all resolve to the same directory regardless of each
+worktree's committed config. Its precedence is:
+
+1. `--project` flag
+2. `--task-dir` / `--dir` flag
+3. `TASKMD_TASK_DIR`
+4. `.taskmd.yaml` (`task-dir` / `dir`)
+5. Built-in default (`.`)
+
+Use an absolute path so it resolves consistently from any working directory.
+
 ## Sync Configuration {#sync-configuration}
 
 The `sync` command reads its configuration from the `sync` section of `.taskmd.yaml`. Each source defines where to fetch tasks from, how to map fields, and where to write files.

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,4 +1,9 @@
-import type { ApiError, Task, TaskUpdateRequest } from "./types.ts";
+import type {
+  ApiError,
+  Task,
+  TaskUpdateRequest,
+  WorklogEntry,
+} from "./types.ts";
 
 export async function fetcher<T>(url: string): Promise<T> {
   const res = await fetch(url);
@@ -25,6 +30,26 @@ export async function updateTask(
 ): Promise<Task> {
   const res = await fetch(`/api/tasks/${id}`, {
     method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) {
+    const body: ApiError = await res.json().catch(() => ({
+      error: `HTTP ${res.status}`,
+    }));
+    throw new ApiRequestError(body.error, body.details);
+  }
+
+  return res.json();
+}
+
+export async function addWorklogEntry(
+  id: string,
+  data: { author?: string; content: string },
+): Promise<WorklogEntry[]> {
+  const res = await fetch(`/api/tasks/${id}/worklog`, {
+    method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -20,6 +20,7 @@ export interface Task {
 
 export interface WorklogEntry {
   timestamp: string;
+  author?: string;
   content: string;
 }
 

--- a/apps/web/src/components/tasks/WorklogSection.tsx
+++ b/apps/web/src/components/tasks/WorklogSection.tsx
@@ -1,13 +1,54 @@
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
+import { addWorklogEntry, ApiRequestError } from "../../api/client.ts";
 import type { WorklogEntry } from "../../api/types.ts";
 
 interface WorklogSectionProps {
   entries: WorklogEntry[];
+  taskId?: string;
+  readonly?: boolean;
+  /** Called after a successful post so the caller can revalidate. */
+  onAdded?: () => void;
 }
 
-export function WorklogSection({ entries }: WorklogSectionProps) {
+export function WorklogSection({
+  entries,
+  taskId,
+  readonly,
+  onAdded,
+}: WorklogSectionProps) {
+  const [content, setContent] = useState("");
+  const [author, setAuthor] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canPost = !!taskId && !readonly;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!taskId || !content.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await addWorklogEntry(taskId, {
+        author: author.trim() || undefined,
+        content: content.trim(),
+      });
+      setContent("");
+      onAdded?.();
+    } catch (err) {
+      setError(
+        err instanceof ApiRequestError
+          ? err.message
+          : "Failed to add worklog entry",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 pt-4 mt-4">
       <h3 className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mb-3">
@@ -18,7 +59,10 @@ export function WorklogSection({ entries }: WorklogSectionProps) {
       </h3>
       <div className="space-y-4">
         {entries.map((entry, i) => (
-          <div key={i} className="border-l-2 border-gray-200 dark:border-gray-600 pl-4">
+          <div
+            key={i}
+            className="border-l-2 border-gray-200 dark:border-gray-600 pl-4"
+          >
             <div className="flex items-center gap-2">
               {entry.author && (
                 <span className="text-xs font-medium text-gray-700 dark:text-gray-200">
@@ -39,7 +83,43 @@ export function WorklogSection({ entries }: WorklogSectionProps) {
             </div>
           </div>
         ))}
+        {entries.length === 0 && (
+          <p className="text-xs text-gray-400">No worklog entries yet.</p>
+        )}
       </div>
+
+      {canPost && (
+        <form onSubmit={handleSubmit} className="mt-4 space-y-2">
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Add a comment… (markdown supported)"
+            rows={3}
+            className="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 p-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={author}
+              onChange={(e) => setAuthor(e.target.value)}
+              placeholder="Author (optional)"
+              className="flex-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+            <button
+              type="submit"
+              disabled={!content.trim() || submitting}
+              className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? "Adding…" : "Comment"}
+            </button>
+          </div>
+          {error && (
+            <p className="text-xs text-red-500" role="alert">
+              {error}
+            </p>
+          )}
+        </form>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/tasks/WorklogSection.tsx
+++ b/apps/web/src/components/tasks/WorklogSection.tsx
@@ -19,9 +19,16 @@ export function WorklogSection({ entries }: WorklogSectionProps) {
       <div className="space-y-4">
         {entries.map((entry, i) => (
           <div key={i} className="border-l-2 border-gray-200 dark:border-gray-600 pl-4">
-            <time className="text-xs text-gray-400 font-mono">
-              {new Date(entry.timestamp).toLocaleString()}
-            </time>
+            <div className="flex items-center gap-2">
+              {entry.author && (
+                <span className="text-xs font-medium text-gray-700 dark:text-gray-200">
+                  {entry.author}
+                </span>
+              )}
+              <time className="text-xs text-gray-400 font-mono">
+                {new Date(entry.timestamp).toLocaleString()}
+              </time>
+            </div>
             <div className="prose prose-sm max-w-none dark:prose-invert mt-1">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}

--- a/apps/web/src/pages/TaskDetailPage.tsx
+++ b/apps/web/src/pages/TaskDetailPage.tsx
@@ -19,7 +19,10 @@ export function TaskDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { project } = useProject();
   const { data: task, error, isLoading, mutate } = useTaskDetail(id, project);
-  const { data: worklogEntries } = useWorklog(id, project);
+  const { data: worklogEntries, mutate: mutateWorklog } = useWorklog(
+    id,
+    project,
+  );
   const { readonly } = useConfig(project);
   const [isEditing, setIsEditing] = useState(false);
   const [editError, setEditError] = useState<string | null>(null);
@@ -184,9 +187,12 @@ export function TaskDetailPage() {
               </div>
             )}
 
-            {worklogEntries && worklogEntries.length > 0 && (
-              <WorklogSection entries={worklogEntries} />
-            )}
+            <WorklogSection
+              entries={worklogEntries ?? []}
+              taskId={id}
+              readonly={readonly}
+              onAdded={() => mutateWorklog()}
+            />
 
             {task.file_path && (
               <div className="mt-4 text-xs text-gray-400 font-mono break-all">

--- a/sdk/go/lock/flock_other.go
+++ b/sdk/go/lock/flock_other.go
@@ -1,0 +1,22 @@
+//go:build !unix
+
+package lock
+
+import (
+	"os"
+	"time"
+)
+
+// flockExclusive is a no-op on platforms without flock support. Cross-process
+// locking is not available here; the in-process mutex in Acquire still
+// serializes goroutines within a single process. This is a deliberate
+// degradation: the primary target for the shared-tracker workflow is unix
+// (darwin, linux).
+func flockExclusive(_ *os.File, _ time.Time) error {
+	return nil
+}
+
+// flockUnlock is a no-op on platforms without flock support.
+func flockUnlock(_ *os.File) error {
+	return nil
+}

--- a/sdk/go/lock/flock_unix.go
+++ b/sdk/go/lock/flock_unix.go
@@ -1,0 +1,34 @@
+//go:build unix
+
+package lock
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+// flockExclusive acquires an exclusive advisory lock on f, retrying the
+// non-blocking flock until the deadline passes.
+func flockExclusive(f *os.File, deadline time.Time) error {
+	fd := int(f.Fd())
+	for {
+		err := syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return nil
+		}
+		if err != syscall.EWOULDBLOCK {
+			return fmt.Errorf("flock: %w", err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for file lock on %s", f.Name())
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+// flockUnlock releases the advisory lock held on f.
+func flockUnlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/sdk/go/lock/lock.go
+++ b/sdk/go/lock/lock.go
@@ -1,0 +1,144 @@
+// Package lock provides lightweight, per-task advisory locking so that
+// multiple processes (parallel agents, the web server, and CLI invocations)
+// can safely share a single task directory.
+//
+// A lock is scoped to a single task ID via a sidecar lock file
+// (<scanDir>/.taskmd/locks/<id>.lock). Holding the lock around a
+// read-modify-write of a task file (or an append to its worklog) prevents
+// lost updates between concurrent writers. Locks on different task IDs never
+// contend, so the common case — agents working on different tasks — is fully
+// parallel.
+//
+// Two layers guard a critical section:
+//
+//   - an in-process mutex keyed by the absolute lock path, which serializes
+//     goroutines within a single process (e.g. concurrent web requests); and
+//   - an OS advisory lock on the sidecar file (flock on unix), which
+//     serializes across processes (e.g. the web server racing a CLI `set`).
+//
+// The OS advisory lock is released automatically if the holding process dies,
+// so there are no stale locks to clean up. Cross-process locking relies on
+// flock and is therefore only guaranteed on unix (darwin, linux) local
+// filesystems; on other platforms locking degrades to in-process only (see
+// flock_other.go). Advisory locks on networked filesystems (NFS) are
+// unreliable and unsupported.
+package lock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// DefaultTimeout is the default maximum time to wait for a lock before failing.
+const DefaultTimeout = 5 * time.Second
+
+// pollInterval is how often we retry a non-blocking lock attempt.
+const pollInterval = 5 * time.Millisecond
+
+// dirPerm and filePerm are the permissions for the locks directory and files.
+const (
+	dirPerm  os.FileMode = 0o755
+	filePerm os.FileMode = 0o644
+)
+
+// procMutexes serializes goroutines within this process, keyed by absolute
+// lock path. flock alone does not reliably arbitrate between two file
+// descriptors opened by the same process, so we layer an in-process mutex on
+// top of it.
+var (
+	procMu      sync.Mutex
+	procMutexes = map[string]*sync.Mutex{}
+)
+
+// Lock is a held advisory lock. Release must be called to free it.
+type Lock struct {
+	f      *os.File
+	inProc *sync.Mutex
+}
+
+// TaskLockPath returns the sidecar lock file path for a task ID within a scan
+// directory, e.g. TaskLockPath("/repo/tasks", "042") ->
+// "/repo/tasks/.taskmd/locks/042.lock".
+func TaskLockPath(scanDir, taskID string) string {
+	return filepath.Join(scanDir, ".taskmd", "locks", taskID+".lock")
+}
+
+// Acquire obtains an exclusive lock on lockPath, blocking up to timeout.
+// It returns an error if the lock cannot be obtained within the timeout.
+func Acquire(lockPath string, timeout time.Duration) (*Lock, error) {
+	abs, err := filepath.Abs(lockPath)
+	if err != nil {
+		abs = lockPath
+	}
+
+	if err := os.MkdirAll(filepath.Dir(abs), dirPerm); err != nil {
+		return nil, fmt.Errorf("create lock directory: %w", err)
+	}
+
+	deadline := time.Now().Add(timeout)
+
+	m := procMutex(abs)
+	if err := acquireProcMutex(m, deadline); err != nil {
+		return nil, err
+	}
+
+	f, err := os.OpenFile(abs, os.O_CREATE|os.O_RDWR, filePerm)
+	if err != nil {
+		m.Unlock()
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	if err := flockExclusive(f, deadline); err != nil {
+		_ = f.Close()
+		m.Unlock()
+		return nil, err
+	}
+
+	return &Lock{f: f, inProc: m}, nil
+}
+
+// Release frees the lock. It is safe to call once; subsequent calls are no-ops.
+func (l *Lock) Release() error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+	err := flockUnlock(l.f)
+	if cerr := l.f.Close(); err == nil {
+		err = cerr
+	}
+	l.f = nil
+	if l.inProc != nil {
+		l.inProc.Unlock()
+		l.inProc = nil
+	}
+	return err
+}
+
+// procMutex returns the shared in-process mutex for a lock path, creating it on
+// first use.
+func procMutex(key string) *sync.Mutex {
+	procMu.Lock()
+	defer procMu.Unlock()
+	m, ok := procMutexes[key]
+	if !ok {
+		m = &sync.Mutex{}
+		procMutexes[key] = m
+	}
+	return m
+}
+
+// acquireProcMutex tries to lock m, retrying until the deadline.
+func acquireProcMutex(m *sync.Mutex, deadline time.Time) error {
+	for {
+		if m.TryLock() {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for in-process lock")
+		}
+		time.Sleep(pollInterval)
+	}
+}

--- a/sdk/go/lock/lock_test.go
+++ b/sdk/go/lock/lock_test.go
@@ -1,0 +1,120 @@
+package lock
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTaskLockPath(t *testing.T) {
+	got := TaskLockPath("/repo/tasks", "042")
+	want := filepath.Join("/repo/tasks", ".taskmd", "locks", "042.lock")
+	if got != want {
+		t.Fatalf("TaskLockPath = %q, want %q", got, want)
+	}
+}
+
+func TestAcquireRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "locks", "x.lock")
+
+	l, err := Acquire(path, DefaultTimeout)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("lock file not created: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	// Double release is a no-op.
+	if err := l.Release(); err != nil {
+		t.Fatalf("second Release: %v", err)
+	}
+
+	// Lock is reusable after release.
+	l2, err := Acquire(path, DefaultTimeout)
+	if err != nil {
+		t.Fatalf("re-Acquire: %v", err)
+	}
+	_ = l2.Release()
+}
+
+func TestAcquireTimesOutWhenHeld(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "held.lock")
+
+	l, err := Acquire(path, DefaultTimeout)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	defer l.Release()
+
+	start := time.Now()
+	if _, err := Acquire(path, 50*time.Millisecond); err == nil {
+		t.Fatal("expected timeout error acquiring a held lock, got nil")
+	}
+	if elapsed := time.Since(start); elapsed < 40*time.Millisecond {
+		t.Fatalf("returned too quickly (%v); did not wait for timeout", elapsed)
+	}
+}
+
+// TestMutualExclusion runs many goroutines that each acquire the same lock,
+// read a shared counter file, increment it, and write it back. With correct
+// locking the final value equals the number of goroutines (no lost updates).
+func TestMutualExclusion(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "counter.lock")
+	counterPath := filepath.Join(dir, "counter")
+	if err := os.WriteFile(counterPath, []byte("0"), 0o644); err != nil {
+		t.Fatalf("seed counter: %v", err)
+	}
+
+	const workers = 50
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			l, err := Acquire(lockPath, 5*time.Second)
+			if err != nil {
+				t.Errorf("Acquire: %v", err)
+				return
+			}
+			defer l.Release()
+			incrementCounter(t, counterPath)
+		}()
+	}
+	wg.Wait()
+
+	if got := readCounter(t, counterPath); got != workers {
+		t.Fatalf("counter = %d, want %d (lost updates indicate broken locking)", got, workers)
+	}
+}
+
+func incrementCounter(t *testing.T, path string) {
+	t.Helper()
+	n := readCounter(t, path)
+	// Widen the race window so a missing lock would reliably corrupt the count.
+	time.Sleep(time.Millisecond)
+	if err := os.WriteFile(path, []byte(strconv.Itoa(n+1)), 0o644); err != nil {
+		t.Errorf("write counter: %v", err)
+	}
+}
+
+func readCounter(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Errorf("read counter: %v", err)
+		return 0
+	}
+	n, err := strconv.Atoi(string(data))
+	if err != nil {
+		t.Errorf("parse counter %q: %v", data, err)
+		return 0
+	}
+	return n
+}

--- a/sdk/go/taskfile/concurrency_test.go
+++ b/sdk/go/taskfile/concurrency_test.go
@@ -1,0 +1,104 @@
+package taskfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestWriteFileAtomic_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.md")
+
+	if err := writeFileAtomic(path, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("content = %q, want %q", got, "hello")
+	}
+
+	// Overwrite replaces content.
+	if err := writeFileAtomic(path, []byte("world"), 0o644); err != nil {
+		t.Fatalf("writeFileAtomic overwrite: %v", err)
+	}
+	got, _ = os.ReadFile(path)
+	if string(got) != "world" {
+		t.Fatalf("content after overwrite = %q, want %q", got, "world")
+	}
+}
+
+func TestWriteFileAtomic_NoTempLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.md")
+	if err := writeFileAtomic(path, []byte("data"), 0o644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".tmp-") {
+			t.Fatalf("leftover temp file: %s", e.Name())
+		}
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 file, got %d", len(entries))
+	}
+}
+
+// TestUpdateTaskFileLocked_ConcurrentAddTags verifies that many concurrent
+// writers each adding a distinct tag all succeed with no lost updates — the
+// core guarantee of the per-task lock plus atomic write. Without locking, the
+// read-modify-write cycles would interleave and drop tags.
+func TestUpdateTaskFileLocked_ConcurrentAddTags(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "010-task.md")
+	seed := `---
+id: "010"
+title: "Concurrent task"
+status: pending
+priority: medium
+effort: small
+tags: []
+created: 2026-02-08
+---
+
+# Concurrent task
+`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	const workers = 30
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(n int) {
+			defer wg.Done()
+			tag := fmt.Sprintf("t%02d", n)
+			req := UpdateRequest{AddTags: []string{tag}}
+			if err := UpdateTaskFileLocked(dir, path, "010", req); err != nil {
+				t.Errorf("UpdateTaskFileLocked: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+	for i := 0; i < workers; i++ {
+		tag := fmt.Sprintf("t%02d", i)
+		if !strings.Contains(string(content), tag) {
+			t.Errorf("tag %q missing — lost update under concurrency", tag)
+		}
+	}
+}

--- a/sdk/go/taskfile/taskfile.go
+++ b/sdk/go/taskfile/taskfile.go
@@ -3,8 +3,10 @@ package taskfile
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/driangle/taskmd/sdk/go/lock"
 	"github.com/driangle/taskmd/sdk/go/model"
 )
 
@@ -133,7 +135,54 @@ func UpdateTaskFile(filePath string, req UpdateRequest) error {
 		lines = replaceBody(lines, closeIdx, *req.Body)
 	}
 
-	return os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0644)
+	return writeFileAtomic(filePath, []byte(strings.Join(lines, "\n")), 0o644)
+}
+
+// UpdateTaskFileLocked acquires the per-task lock for taskID (scoped to scanDir)
+// and then performs UpdateTaskFile within the critical section. This serializes
+// concurrent writers to the same task across processes (parallel agents, the
+// web server, and CLI invocations) sharing a task directory, preventing lost
+// updates.
+func UpdateTaskFileLocked(scanDir, filePath, taskID string, req UpdateRequest) error {
+	l, err := lock.Acquire(lock.TaskLockPath(scanDir, taskID), lock.DefaultTimeout)
+	if err != nil {
+		return fmt.Errorf("lock task %s: %w", taskID, err)
+	}
+	defer l.Release()
+	return UpdateTaskFile(filePath, req)
+}
+
+// writeFileAtomic writes data to path atomically: it writes to a temporary file
+// in the same directory, fsyncs it, then renames it over the target. Readers
+// therefore never observe a partially written file — they see either the old
+// contents or the complete new contents.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-"+filepath.Base(path)+"-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	return nil
 }
 
 type scalarUpdate struct {
@@ -491,7 +540,7 @@ func ReplaceID(filePath, newID string) error {
 	for i := openIdx + 1; i < closeIdx; i++ {
 		if strings.HasPrefix(strings.TrimSpace(lines[i]), "id:") {
 			lines[i] = fmt.Sprintf("id: %q", newID)
-			return os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0644)
+			return writeFileAtomic(filePath, []byte(strings.Join(lines, "\n")), 0o644)
 		}
 	}
 
@@ -520,7 +569,7 @@ func ReplaceReference(filePath, oldID, newID string) error {
 		return nil
 	}
 
-	return os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0644)
+	return writeFileAtomic(filePath, []byte(strings.Join(lines, "\n")), 0o644)
 }
 
 // replaceRefsInLines performs the actual replacement of oldID with newID within frontmatter lines.

--- a/sdk/go/worklog/worklog.go
+++ b/sdk/go/worklog/worklog.go
@@ -14,6 +14,7 @@ import (
 // Entry is a single timestamped worklog entry.
 type Entry struct {
 	Timestamp time.Time `json:"timestamp" yaml:"timestamp"`
+	Author    string    `json:"author,omitempty" yaml:"author,omitempty"`
 	Content   string    `json:"content" yaml:"content"`
 }
 
@@ -24,8 +25,11 @@ type Worklog struct {
 	Entries  []Entry `json:"entries" yaml:"entries"`
 }
 
-// timestampHeader matches "## <ISO-8601 timestamp>" headings.
-var timestampHeader = regexp.MustCompile(`^## (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2}))`)
+// timestampHeader matches "## <ISO-8601 timestamp>" headings, with an optional
+// " — <author>" suffix (an em dash or hyphen separator is accepted). Group 1 is
+// the timestamp; group 2 is the author (empty when omitted, e.g. legacy
+// entries written before author attribution).
+var timestampHeader = regexp.MustCompile(`^## (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2}))(?:\s+[—-]\s+(.+?))?\s*$`)
 
 // ParseWorklog reads a worklog file and splits it into entries on ## timestamp headings.
 func ParseWorklog(filePath string) (*Worklog, error) {
@@ -51,7 +55,7 @@ func parseEntries(content string) []Entry {
 	var contentLines []string
 
 	for _, line := range lines {
-		if m := timestampHeader.FindStringSubmatch(line); len(m) == 2 {
+		if m := timestampHeader.FindStringSubmatch(line); len(m) >= 2 {
 			// Flush previous entry
 			if current != nil {
 				current.Content = strings.TrimSpace(strings.Join(contentLines, "\n"))
@@ -64,7 +68,11 @@ func parseEntries(content string) []Entry {
 				contentLines = nil
 				continue
 			}
-			current = &Entry{Timestamp: ts}
+			author := ""
+			if len(m) > 2 {
+				author = strings.TrimSpace(m[2])
+			}
+			current = &Entry{Timestamp: ts, Author: author}
 			contentLines = nil
 		} else if current != nil {
 			contentLines = append(contentLines, line)
@@ -95,14 +103,19 @@ func WorklogPath(taskFilePath string, taskID string) string {
 }
 
 // AppendEntry appends a new timestamped entry to a worklog file,
-// creating the file and .worklogs/ directory if needed.
-func AppendEntry(filePath string, message string) error {
+// creating the file and .worklogs/ directory if needed. If author is non-empty
+// it is recorded in the entry heading as "## <timestamp> — <author>".
+func AppendEntry(filePath, author, message string) error {
 	dir := filepath.Dir(filePath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create worklogs directory: %w", err)
 	}
 
-	entry := fmt.Sprintf("\n## %s\n\n%s\n", time.Now().UTC().Format(time.RFC3339), message)
+	header := "## " + time.Now().UTC().Format(time.RFC3339)
+	if a := strings.TrimSpace(author); a != "" {
+		header += " — " + a
+	}
+	entry := fmt.Sprintf("\n%s\n\n%s\n", header, message)
 
 	// If file doesn't exist, create it without leading newline
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
@@ -125,13 +138,13 @@ func AppendEntry(filePath string, message string) error {
 // AppendEntryLocked appends a worklog entry while holding the per-task lock
 // (scoped to scanDir), serializing it against concurrent worklog appends and
 // task-file writes for the same task ID across processes.
-func AppendEntryLocked(scanDir, filePath, taskID, message string) error {
+func AppendEntryLocked(scanDir, filePath, taskID, author, message string) error {
 	l, err := lock.Acquire(lock.TaskLockPath(scanDir, taskID), lock.DefaultTimeout)
 	if err != nil {
 		return fmt.Errorf("lock task %s: %w", taskID, err)
 	}
 	defer l.Release()
-	return AppendEntry(filePath, message)
+	return AppendEntry(filePath, author, message)
 }
 
 // Exists checks whether a worklog file exists for the given path.

--- a/sdk/go/worklog/worklog.go
+++ b/sdk/go/worklog/worklog.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/driangle/taskmd/sdk/go/lock"
 )
 
 // Entry is a single timestamped worklog entry.
@@ -118,6 +120,18 @@ func AppendEntry(filePath string, message string) error {
 	}
 
 	return nil
+}
+
+// AppendEntryLocked appends a worklog entry while holding the per-task lock
+// (scoped to scanDir), serializing it against concurrent worklog appends and
+// task-file writes for the same task ID across processes.
+func AppendEntryLocked(scanDir, filePath, taskID, message string) error {
+	l, err := lock.Acquire(lock.TaskLockPath(scanDir, taskID), lock.DefaultTimeout)
+	if err != nil {
+		return fmt.Errorf("lock task %s: %w", taskID, err)
+	}
+	defer l.Release()
+	return AppendEntry(filePath, message)
 }
 
 // Exists checks whether a worklog file exists for the given path.

--- a/sdk/go/worklog/worklog_test.go
+++ b/sdk/go/worklog/worklog_test.go
@@ -176,7 +176,7 @@ func TestAppendEntry_CreatesFileAndDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	wlFile := filepath.Join(tmpDir, ".worklogs", "015.md")
 
-	err := AppendEntry(wlFile, "First entry")
+	err := AppendEntry(wlFile, "", "First entry")
 	if err != nil {
 		t.Fatalf("AppendEntry failed: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestAppendEntry_AppendsToExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := AppendEntry(wlFile, "New entry")
+	err := AppendEntry(wlFile, "", "New entry")
 	if err != nil {
 		t.Fatalf("AppendEntry failed: %v", err)
 	}
@@ -275,5 +275,78 @@ func TestExists(t *testing.T) {
 
 	if !Exists(wlFile) {
 		t.Error("Expected Exists to return true for existing file")
+	}
+}
+
+func TestAppendEntry_WithAuthor(t *testing.T) {
+	wlFile := filepath.Join(t.TempDir(), ".worklogs", "015.md")
+
+	if err := AppendEntry(wlFile, "Guilherme", "Started work"); err != nil {
+		t.Fatalf("AppendEntry: %v", err)
+	}
+
+	data, err := os.ReadFile(wlFile)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), "— Guilherme") {
+		t.Errorf("heading missing author separator/name, got:\n%s", data)
+	}
+
+	wl, err := ParseWorklog(wlFile)
+	if err != nil {
+		t.Fatalf("ParseWorklog: %v", err)
+	}
+	if len(wl.Entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(wl.Entries))
+	}
+	if got := wl.Entries[0].Author; got != "Guilherme" {
+		t.Errorf("Author = %q, want %q", got, "Guilherme")
+	}
+	if got := wl.Entries[0].Content; got != "Started work" {
+		t.Errorf("Content = %q, want %q", got, "Started work")
+	}
+}
+
+func TestAppendEntry_AuthorWithSpaces(t *testing.T) {
+	wlFile := filepath.Join(t.TempDir(), "016.md")
+	if err := AppendEntry(wlFile, "claude (agent)", "auto update"); err != nil {
+		t.Fatalf("AppendEntry: %v", err)
+	}
+	wl, err := ParseWorklog(wlFile)
+	if err != nil {
+		t.Fatalf("ParseWorklog: %v", err)
+	}
+	if got := wl.Entries[0].Author; got != "claude (agent)" {
+		t.Errorf("Author = %q, want %q", got, "claude (agent)")
+	}
+}
+
+// TestParseWorklog_LegacyAndAuthored verifies backward compatibility: a file
+// mixing a legacy (no-author) entry and an authored entry parses both, with the
+// legacy entry reporting an empty author.
+func TestParseWorklog_LegacyAndAuthored(t *testing.T) {
+	wlFile := filepath.Join(t.TempDir(), "017.md")
+	content := "## 2026-02-15T10:00:00Z\n\nLegacy entry.\n\n" +
+		"## 2026-02-16T11:00:00Z — Guilherme\n\nAuthored entry.\n"
+	if err := os.WriteFile(wlFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	wl, err := ParseWorklog(wlFile)
+	if err != nil {
+		t.Fatalf("ParseWorklog: %v", err)
+	}
+	if len(wl.Entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(wl.Entries))
+	}
+	if wl.Entries[0].Author != "" {
+		t.Errorf("legacy entry Author = %q, want empty", wl.Entries[0].Author)
+	}
+	if wl.Entries[0].Content != "Legacy entry." {
+		t.Errorf("legacy Content = %q", wl.Entries[0].Content)
+	}
+	if wl.Entries[1].Author != "Guilherme" {
+		t.Errorf("authored entry Author = %q, want %q", wl.Entries[1].Author, "Guilherme")
 	}
 }


### PR DESCRIPTION
## Summary

Turns worklogs into GitHub-issue-style comment threads and makes a task directory safe to share across parallel agents. Four self-contained commits:

1. **`feat(concurrency)`** — safe shared task directory
   - New `sdk/go/lock` package: lightweight **per-task advisory lock** (`<task-dir>/.taskmd/locks/<id>.lock`) — in-process mutex + `flock` on unix, degrading to in-process on other platforms.
   - **Atomic writes** (temp + fsync + rename) replace the previous `O_TRUNC` writes, so readers never see a partially-written task file.
   - **`TASKMD_TASK_DIR`** env override so multiple git worktrees can point at one shared tracker (precedence: explicit flag > env > `.taskmd.yaml` > default).
   - Wired into every mutating path: CLI `set`, web `PUT`, MCP `set`, and worklog append.

2. **`feat(worklog)`** — author attribution
   - `Entry` gains an `Author`; heading format extended to `## <timestamp> — <author>` (backward compatible — legacy author-less entries still parse).
   - `worklog --add --author`, defaulting to git `user.name` → `user.email` → `$USER`. Shown in text/JSON output.

3. **`feat(web)`** — post comments from the web UI
   - `POST /api/tasks/{id}/worklog` (honors read-only mode) + a comment box in the task detail page. Also fixes the GET/export paths that were dropping the author field.

4. **`docs`** — documents all of the above on the VitePress site (configuration, best-practices, cli, web).

## Motivation

Worktree-per-agent isolates work but gives each agent a *private copy* of `tasks/`, so status/comments aren't shared live and reconcile only via merges. Pointing every process at one shared directory fixes that — but a shared dir needs write safety, which taskmd previously lacked (no locking, non-atomic writes). These changes provide the safety and the shared-tracker switch, then layer authored comments on top.

## Testing

- New unit tests: `lock` (incl. 50-goroutine mutual-exclusion), `taskfile` concurrency (30 concurrent authored writes, no lost updates), `worklog` author roundtrip + legacy compat, `env_task_dir`, and web `handleAddWorklog` (success/read-only/empty/not-found).
- Full SDK + CLI suites, e2e, `go vet`, `gofmt`, web typecheck, web component tests, and VitePress build all pass.
- **Cross-process check:** 40 concurrent `taskmd set` processes on one task — pre-change binary lost 15–30 of 40 tag updates per run; this branch loses **zero**.
- **Web UI:** verified end-to-end in a browser (embedded build) — posted a comment, saw it render with author + markdown, confirmed persistence to the worklog file via the locked path.

## Notes / caveats

- `flock` is reliable on local filesystems (macOS/Linux); not guaranteed on NFS.
- Windows falls back to in-process-only locking (documented; behind build tags).
- The sync writer (`internal/sync`) keeps atomic writes but is not lock-protected (single-process batch import).
- Docs updated on the live VitePress site only; the legacy `docs/guides/*` mirrors and the worklog-less canonical spec were intentionally left untouched.
- `golangci-lint` wasn't available in my environment — used `go vet` + `gofmt`. Worth a lint run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
